### PR TITLE
First page is fetched twice

### DIFF
--- a/js/lastfm-export.js
+++ b/js/lastfm-export.js
@@ -21,14 +21,14 @@ function requestData(api_key, user, page){
     user:user,
     api_key:api_key,
     limit:200,
-    page: page || 0
+    page: page || 1
   }
 }
 
 // generate a list of request data objects
 function requestList(api_key, user, page_count){
   var requests = [];
-  for(var page = 0; page <= page_count; page++){
+  for(var page = 1; page <= page_count; page++){
     requests.push(requestData(api_key, user, page))
   }
   return requests


### PR DESCRIPTION
Hi, first of all - great tool!
I noticed that you fetch the first page of results twice - you start  from page 0, but this is an invalid page in the API, so when you call it it just returns the results for page 1. Then you fetch page 1 again, so in the end you get 200 extra tracks in the final result..