### PR TITLE
Add warning to users regarding adblock

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     </div>
     <p class="lead">This fetches data from the lastfm api, and formats it as a csv document</p>
 
-    <div class="alert alert-warning" style="display:none" rv-show="user_error">Couldn't find user</div>
+    <div class="alert alert-warning" style="display:none" rv-show="user_error">Couldn't find user. This error may also occur if you have AdBlock enabled.</div>
 
     <form class="form-inline">
       <div class="form-group" rv-class-has-error="user_error">


### PR DESCRIPTION
Add a simple extra to the "couldn't find user" error, just in case the user has adblock enabled (like I did, when i realized i found the "error" why it wasn't working).