### PR TITLE
Add warning to users with hidden information

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,11 @@
     </div>
     <p class="lead">This fetches data from the lastfm api, and formats it as a csv document</p>
 
-    <div class="alert alert-warning" style="display:none" rv-show="user_error">Couldn't find user. This error may also occur if you have AdBlock enabled.</div>
+    <div class="alert alert-warning" style="display:none" rv-show="user_error">
+      Couldn't find user.
+      This error may also occur if you have AdBlock enabled,
+      or if you've chosen to "Hide recent listening information" in the Last.fm privacy settings.
+    </div>
 
     <form class="form-inline">
       <div class="form-group" rv-class-has-error="user_error">


### PR DESCRIPTION
In the [Last.fm privacy settings](https://www.last.fm/settings/privacy), there is an option to hide recent listening information from your profile which, if active, causes the user error.

I've turned this on a while ago and then a couple days later I tried to back up my scrobbling data. Obviously I've since forgot that this option even exists and so it took me some time to figure out why I was getting the error. So hopefully this warning message is useful to others.